### PR TITLE
Escape potential spaces in file paths used by ffmpeg

### DIFF
--- a/inference_video.py
+++ b/inference_video.py
@@ -28,17 +28,17 @@ def transferAudio(sourceVideo, targetVideo):
         # create new "temp" directory
         os.makedirs("temp")
         # extract audio from video
-        os.system("ffmpeg -y -i " + sourceVideo + " -c:a copy -vn " + tempAudioFileName)
+        os.system('ffmpeg -y -i "{}" -c:a copy -vn {}'.format(sourceVideo, tempAudioFileName))
     
     targetNoAudio = os.path.splitext(targetVideo)[0] + "_noaudio" + os.path.splitext(targetVideo)[1]
     os.rename(targetVideo, targetNoAudio)
     # combine audio file and new video file
-    os.system("ffmpeg -y -i " + targetNoAudio + " -i " + tempAudioFileName + " -c copy " + targetVideo)
+    os.system('ffmpeg -y -i "{}" -i {} -c copy "{}"'.format(targetNoAudio, tempAudioFileName, targetVideo))
     
     if os.path.getsize(targetVideo) == 0: # if ffmpeg failed to merge the video and audio together try converting the audio to aac
         tempAudioFileName = "./temp/audio.m4a"
-        os.system("ffmpeg -y -i " + sourceVideo + " -c:a aac -b:a 160k -vn " + tempAudioFileName)
-        os.system("ffmpeg -y -i " + targetNoAudio + " -i " + tempAudioFileName + " -c copy " + targetVideo)
+        os.system('ffmpeg -y -i "{}" -c:a aac -b:a 160k -vn {}'.format(sourceVideo, tempAudioFileName))
+        os.system('ffmpeg -y -i "{}" -i {} -c copy "{}"'.format(targetNoAudio, tempAudioFileName, targetVideo))
         if (os.path.getsize(targetVideo) == 0): # if aac is not supported by selected format
             os.rename(targetNoAudio, targetVideo)
             print("Audio transfer failed. Interpolated video will have no audio")


### PR DESCRIPTION
I encapsulated the variables used in os.system() calls to ffmpeg in parenthesis to escape any spaces that might be in the filepaths or names of --video or --output. Previously --video="test file.mp4" would execute 'ffmpeg -y -i test file.mp4 -c:a copy -vn ./temp/audio.mkv' and ffmpeg would error with "test: No such file or directory". Now it will execute as 'ffmpeg -y -i "test file.mp4" -c:a copy -vn ./temp/audio.mkv' and the space will be properly treated as part of the file name